### PR TITLE
Update email_plugin_verwenden.md / value_pool auslesen

### DIFF
--- a/de_de/email_plugin_verwenden.md
+++ b/de_de/email_plugin_verwenden.md
@@ -35,7 +35,7 @@ if($form) { // Wenn das Formular nicht abgesendet wurde
 	$debug = 0;
 
 	// Array mit Platzhaltern, die im E-Mail-Template ersetzt werden.
-	$values = $this->params['value_pool']['email'];
+	$values = $yform->objparams['value_pool']['email'];
 	$values['custom'] = 'Eigener Platzhalter';
 
 	if ($yform_email_template = rex_yform_email_template::getTemplate($yform_email_template_key)) {


### PR DESCRIPTION
habe gerade vergeblich versucht das snippet **Variante 1: tpl2email in einem yForm-PHP-Modul simulieren** zu nutzen. 
erst nachdem ich `$this->params['value_pool']['email']` in `$yform->objparams['value_pool']['email']` geändert habe hat es funktioniert (yform 3.0-beta2)